### PR TITLE
Fix on event counting

### DIFF
--- a/pythonvideoannotator/modules/events_statistics/stats.py
+++ b/pythonvideoannotator/modules/events_statistics/stats.py
@@ -211,7 +211,8 @@ class Stats(BaseWidget):
                     spamwriter.writerow([label])
                     spamwriter.writerow(['Period', ' Duration (s)', ' Total', ' Occurrences'])
                     events_occur = self._find_occurrences(self._duration[label])
-                    for k, frame_idx in enumerate(range(experiment_start_frame_idx, experiment_end_frame_idx, framesBin)):
+                    for k, frame_idx in enumerate(range(experiment_start_frame_idx, experiment_end_frame_idx, int(framesBin))):
+				
                         groups = self.__event_groups_in_frames_threshold(events_occur, frame_idx, frame_idx + framesBin)
                         groups_count = len(groups)
                         frames_count = sum(self._duration[label][frame_idx:frame_idx + framesBin])

--- a/pythonvideoannotator/modules/events_statistics/stats.py
+++ b/pythonvideoannotator/modules/events_statistics/stats.py
@@ -246,11 +246,12 @@ class Stats(BaseWidget):
 
     def __event_groups_in_frames_threshold(self, events_occur, frames_threshold_first_index, frames_threshold_last_index):
         """
-        Returns list with events occurrences (groups)
+        Returns list with events occurrences (groups) starting at frames_threshold_first_index, and before frames_threshold_last_index
         e.g. 
-        events_occur = [1, 2, 4, 5, 6, 8, 11, 12, 13, 14, 15, 16, 17, 18]
+        events_occur = [1, 2, 4, 5, 6, 8, 11, 12, 13, 14, 15, 16]
+        frames_threshold_first_index = 5
         frames_threshold_last_index = 15 
-        returns [[1, 2], [4, 5, 6], [8], [11, 12, 13, 14, 15, 16, 17, 18]]
+        returns [[8], [11, 12, 13, 14, 15, 16]
         """
         prev = events_occur[0]
         last = 0
@@ -262,7 +263,7 @@ class Stats(BaseWidget):
             prev = i
         final.append(events_occur[last:])
 
-        return list(occur for occur in final if occur[0] >= frames_threshold_first_index and occur[0] <= frames_threshold_last_index)
+        return list(occur for occur in final if occur[0] >= frames_threshold_first_index and occur[0] < frames_threshold_last_index)
 
     def __generate_graph(self):
         self.__do_the_calculations()


### PR DESCRIPTION
Olá,

Diana had a small issue when using "export totals" in the "event stats" window, resulting in extra counts. This was because events that ended at exactly the end of a frame were counted twice: an event in frames 18,19,20 would be part of group (10-20) and also (20-30), for example.
